### PR TITLE
Fix "Missing baseUrl" message

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,6 @@
     "strictPropertyInitialization": false,
     "types": ["jest", "node"], // see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311
     "skipLibCheck": true,
+    "baseUrl": "."
   }
 }


### PR DESCRIPTION
Fixes the message below from when the typescript gets compiled:
```
Missing baseUrl in compilerOptions. tsconfig-paths will be skipped
```