### PR TITLE
not allowing art share when location isn't available

### DIFF
--- a/web/src/view/page/UploadPage.tsx
+++ b/web/src/view/page/UploadPage.tsx
@@ -72,8 +72,8 @@ export function UploadPage(props: UploadPageProps) {
         variables: { art: art },
       })
     } else {
-      console.log('waiting for location')
-      setTimeout(fileUploadHandler, 250)
+      console.log('art not shared: location services were not enabled')
+      alert('Art not shared: location services were not enabled')
     }
   }
 
@@ -146,18 +146,18 @@ export function UploadPage(props: UploadPageProps) {
             <br></br>
             <br></br>
             <br></br>
-            <br></br>
           </>
         )}
         <br></br>
         <div className="flex justify-center">
           <Share getLocation={() => location} setLocation={(lat: number, lng: number) => setLocation({ lat, lng })} />
         </div>
+        <Spacer $h1 />
         <div className="flex justify-center">
           <PillButton
             $pillColor="purple"
             style={disabledStyles}
-            onClick={() => fileUploadHandler().then(() => navigate(getMapPath()))}
+            onClick={() => location != null && fileUploadHandler().then(() => navigate(getMapPath()))}
           >
             Share
           </PillButton>

--- a/web/src/view/upload/Share.tsx
+++ b/web/src/view/upload/Share.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+interface ShareProps {
+  getLocation: () => { lat: number; lng: number } | null
+  setLocation: (lat: number, lng: number) => void
+}
+
+export function Share({ getLocation, setLocation }: ShareProps) {
+  if (typeof navigator !== 'undefined' && navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(c => {
+      setLocation(c.coords.latitude, c.coords.longitude)
+    })
+  }
+
+  const location = getLocation()
+
+  if (!location) return <div>Please enable location services!</div>
+  return <div></div>
+}


### PR DESCRIPTION
disable the "Share" button and add "Please enable location services!" on upload page when location is not available.

<img width="561" alt="Screen Shot 2020-12-09 at 9 41 19 AM" src="https://user-images.githubusercontent.com/12820496/101666195-c2f34300-3a02-11eb-80c1-0b6418d429d7.png">
